### PR TITLE
fix: Updates usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install --save react-octadground
 ## Usage
 
 ```js
-import Octadground from 'react-octadground'
+import Octadground from 'react-octadground/octadground'
 import 'react-octadground/dist/styles/octadground.css'
 
 const Demo: FC = props => {


### PR DESCRIPTION
The import for `Octadground` was incorrect for the usage example in the README.md. This fixes that.