### PR TITLE
onMove returns game pieces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-octadground",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "React wrapper for octadground <https://github.com/dechristopher/octadground>",
   "main": "index.js",
   "module": "example/demo/src/es/index.js",
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/dechristopher/react-octadground",
   "dependencies": {
-    "octadground": "1.0.2"
+    "octadground": "1.0.3"
   },
   "peerDependencies": {
     "react": "17.0.1",

--- a/src/octadground.tsx
+++ b/src/octadground.tsx
@@ -1,10 +1,10 @@
 import React, {CSSProperties, FC, useEffect, useRef, useState} from 'react'
 import { Octadground as NativeOctadground } from 'octadground'
 import {Api} from "octadground/api";
-import {Key, Piece} from "octadground/types";
+import {Key, Piece, Pieces} from "octadground/types";
 import {Config} from "octadground/config";
 
-export { Key, Piece };
+export { Key, Piece, Pieces };
 
 type PlayPremoveFunction = () => boolean;
 
@@ -31,7 +31,7 @@ export interface OctadgroundProps {
   draggable?: Config["draggable"];
   selectable?: Config["selectable"];
   onChange?: () => void;
-  onMove?: (orig: Key, dest: Key, capturedPiece?: Piece) => void;
+  onMove?: (orig: Key, dest: Key, pieces: Pieces, capturedPiece?: Piece) => void;
   onDropNewPiece?: (piece: Piece, key: Key) => void;
   onSelect?: (key: Key) => void;
   drawable?: Config["drawable"];


### PR DESCRIPTION
## Changes

- Updates the `onMove` interface to return all game pieces present on the board.
- Re-exports the `Pieces` type from `octadground`.